### PR TITLE
added guild name to update function for allowed_invites

### DIFF
--- a/morpheushelper/cogs/invites.py
+++ b/morpheushelper/cogs/invites.py
@@ -213,7 +213,7 @@ class InvitesCog(Cog, name="Allowed Discord Invites"):
         if not await Permission.invite_manage.check_permissions(ctx.author) and ctx.author.id != row.applicant:
             raise CommandError(translations.not_allowed)
 
-        await db_thread(AllowedInvite.update, guild.id, invite.code)
+        await db_thread(AllowedInvite.update, guild.id, invite.code, guild.name)
         await ctx.send(translations.f_invite_updated(row.guild_name))
         await send_to_changelog(ctx.guild, translations.f_log_invite_updated(ctx.author.mention, row.guild_name))
 

--- a/morpheushelper/models/allowed_invite.py
+++ b/morpheushelper/models/allowed_invite.py
@@ -30,9 +30,10 @@ class AllowedInvite(db.Base):
         return row
 
     @staticmethod
-    def update(guild_id: int, code: str):
-        row = db.get(AllowedInvite, guild_id)
+    def update(guild_id: int, code: str, guild_name: str):
+        row: AllowedInvite = db.get(AllowedInvite, guild_id)
         row.code = code
+        row.guild_name = guild_name
 
 
 class InviteLog(db.Base):


### PR DESCRIPTION
**Description**
Updating the invite code of an allowed invite will now update the guild name as well.