### PR TITLE
added vscode generated config files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -302,3 +302,6 @@ $RECYCLE.BIN/
 *.lnk
 
 # End of https://www.toptal.com/developers/gitignore/api/intellij+all,python,windows,linux,macos
+
+# Visual Studio Code generated config dir
+.vscode


### PR DESCRIPTION
Vscode usually generates a directory named .vscode, which contains some configuration files for the current workspace. Added the directory to .gitignore.
